### PR TITLE
add support for magento version 2.3.3 and php version 7.3

### DIFF
--- a/Console/StartConsumerCommand.php
+++ b/Console/StartConsumerCommand.php
@@ -140,7 +140,7 @@ class StartConsumerCommand extends Command
             self::OPTION_MESSAGE_RUN_ONCE,
             null,
             InputOption::VALUE_NONE,
-            'Requeue messages on failure (1 to enable, 0 to disable).'
+            'Stop Process when queue is empty'
         );
 
         parent::configure();

--- a/Console/StartConsumerCommand.php
+++ b/Console/StartConsumerCommand.php
@@ -87,9 +87,7 @@ class StartConsumerCommand extends Command
                 if($runOnce){
                     break;
                 }
-                else{
-                    continue;
-                }
+                continue;
             }
 
             try {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         }
     ],
     "require": {
-        "php": "~7.1.0|~7.2.0",
+        "php": "~7.1.0|~7.2.0|~7.3.0",
         "symfony/console": "~4.1.9",
         "magento/framework": "102.0.*",
         "magento/module-store": "101.0.*"


### PR DESCRIPTION
Hi Renato,
i updated the Module for the update to Magento 2.3.3 and update to php version 7.3.
I tested it and for me it works.

Looks like i missed to update the travis.yml.
